### PR TITLE
PlayerCombat bug fixes

### DIFF
--- a/Assets/Assets/Hero Knight - Pixel Art/Animations/HeroKnight_AnimController.controller
+++ b/Assets/Assets/Hero Knight - Pixel Art/Animations/HeroKnight_AnimController.controller
@@ -507,199 +507,199 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Speed
     m_Type: 1
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Jumping
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: isFalling
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Block
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: IdleBlock
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Hurt
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Death
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: noBlood
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: AirSpeedY
     m_Type: 1
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Grounded
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Jump
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Roll
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: WallSlide
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: isRolling
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: == temp divider ==
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: move
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: idle
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: placeholder
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: xVelocity
     m_Type: 1
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: yVelocity
     m_Type: 1
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: inAir
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: land
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: isAttacking
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: firstAttack
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Attack1
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Attack2
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Attack3
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: canAttack
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Attack1Heavy
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Attack2Heavy
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Attack3Heavy
     m_Type: 9
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: Stunned
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -911,7 +911,7 @@ AnimatorStateMachine:
   m_ChildStates:
   - serializedVersion: 1
     m_State: {fileID: 110215012}
-    m_Position: {x: 130, y: 110, z: 0}
+    m_Position: {x: 130, y: 120, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 110290548}
     m_Position: {x: -560, y: -50, z: 0}

--- a/Assets/Assets/Hero Knight - Pixel Art/Animations/HeroKnight_AnimController.controller
+++ b/Assets/Assets/Hero Knight - Pixel Art/Animations/HeroKnight_AnimController.controller
@@ -676,12 +676,6 @@ AnimatorController:
     m_DefaultInt: 0
     m_DefaultBool: 0
     m_Controller: {fileID: 0}
-  - m_Name: Stunned
-    m_Type: 9
-    m_DefaultFloat: 0
-    m_DefaultInt: 0
-    m_DefaultBool: 0
-    m_Controller: {fileID: 0}
   - m_Name: Attack1Heavy
     m_Type: 9
     m_DefaultFloat: 0
@@ -696,6 +690,12 @@ AnimatorController:
     m_Controller: {fileID: 0}
   - m_Name: Attack3Heavy
     m_Type: 9
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 0}
+  - m_Name: Stunned
+    m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
@@ -917,7 +917,7 @@ AnimatorStateMachine:
     m_Position: {x: -560, y: -50, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 110273628}
-    m_Position: {x: 420, y: 360, z: 0}
+    m_Position: {x: 20, y: 310, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 110242590}
     m_Position: {x: 980, y: 350, z: 0}
@@ -926,25 +926,25 @@ AnimatorStateMachine:
     m_Position: {x: 1020, y: 240, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 1102940124560247288}
-    m_Position: {x: 720, y: -60, z: 0}
+    m_Position: {x: 720, y: -230, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 1102752457226709052}
-    m_Position: {x: 132, y: -60, z: 0}
+    m_Position: {x: 130, y: -230, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 1102211112815620450}
-    m_Position: {x: 420, y: 108, z: 0}
+    m_Position: {x: 430, y: -10, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 1102510671916804920}
-    m_Position: {x: 420, y: 156, z: 0}
+    m_Position: {x: 430, y: 40, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 1102437315657518208}
-    m_Position: {x: 420, y: 204, z: 0}
+    m_Position: {x: 430, y: 90, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 1102030121162160510}
-    m_Position: {x: 528, y: 48, z: 0}
+    m_Position: {x: 520, y: -140, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 1102300704502506890}
-    m_Position: {x: 290, y: 10, z: 0}
+    m_Position: {x: 280, y: -180, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 1102178466039808638}
     m_Position: {x: 420, y: 264, z: 0}
@@ -962,7 +962,7 @@ AnimatorStateMachine:
     m_Position: {x: 550, y: 520, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 3560669213239200412}
-    m_Position: {x: 420, y: 740, z: 0}
+    m_Position: {x: 420, y: 700, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 595830085046736454}
     m_Position: {x: 550, y: 570, z: 0}
@@ -974,7 +974,7 @@ AnimatorStateMachine:
     m_Position: {x: -490, y: -180, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 8167236333757197180}
-    m_Position: {x: 420, y: 410, z: 0}
+    m_Position: {x: 20, y: 360, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 6161476817774095061}
     m_Position: {x: 300, y: 520, z: 0}
@@ -1011,7 +1011,7 @@ AnimatorStateMachine:
   - {fileID: -6632984369177040655}
   m_StateMachineTransitions: {}
   m_StateMachineBehaviours: []
-  m_AnyStatePosition: {x: 744, y: 108, z: 0}
+  m_AnyStatePosition: {x: 750, y: 120, z: 0}
   m_EntryPosition: {x: -160, y: 70, z: 0}
   m_ExitPosition: {x: -540, y: 470, z: 0}
   m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
@@ -1499,7 +1499,7 @@ AnimatorStateTransition:
   m_TransitionOffset: 0
   m_ExitTime: 1
   m_HasExitTime: 1
-  m_HasFixedDuration: 0
+  m_HasFixedDuration: 1
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
@@ -2197,9 +2197,9 @@ AnimatorStateTransition:
   serializedVersion: 3
   m_TransitionDuration: 0
   m_TransitionOffset: 0
-  m_ExitTime: 0.75
-  m_HasExitTime: 0
-  m_HasFixedDuration: 0
+  m_ExitTime: 0
+  m_HasExitTime: 1
+  m_HasFixedDuration: 1
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
@@ -2482,7 +2482,10 @@ AnimatorStateTransition:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: 
-  m_Conditions: []
+  m_Conditions:
+  - m_ConditionMode: 2
+    m_ConditionEvent: Stunned
+    m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: 110215012}
   m_Solo: 0

--- a/Assets/Assets/Hero Knight - Pixel Art/Animations/HeroKnight_Idle.anim
+++ b/Assets/Assets/Hero Knight - Pixel Art/Animations/HeroKnight_Idle.anim
@@ -30,6 +30,15 @@ AnimationClip:
         inWeight: 0.33333334
         outWeight: 0.33333334
       - serializedVersion: 3
+        time: 0.5
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
         time: 1
         value: 0
         inSlope: 0
@@ -123,6 +132,15 @@ AnimationClip:
       m_Curve:
       - serializedVersion: 3
         time: 0
+        value: 0
+        inSlope: 0
+        outSlope: 0
+        tangentMode: 136
+        weightedMode: 0
+        inWeight: 0.33333334
+        outWeight: 0.33333334
+      - serializedVersion: 3
+        time: 0.5
         value: 0
         inSlope: 0
         outSlope: 0

--- a/Assets/Assets/Hero Knight - Pixel Art/Animations/HeroKnight_Stunned.anim
+++ b/Assets/Assets/Hero Knight - Pixel Art/Animations/HeroKnight_Stunned.anim
@@ -52,7 +52,7 @@ AnimationClip:
     m_AdditiveReferencePoseClip: {fileID: 0}
     m_AdditiveReferencePoseTime: 0
     m_StartTime: 0
-    m_StopTime: 0.90909094
+    m_StopTime: 0.9090909
     m_OrientationOffsetY: 0
     m_Level: 0
     m_CycleOffset: 0
@@ -79,7 +79,7 @@ AnimationClip:
     floatParameter: 0
     intParameter: 0
     messageOptions: 0
-  - time: 0.90909094
+  - time: 0.8181818
     functionName: ResetMaterial
     data: 
     objectReferenceParameter: {fileID: 0}

--- a/Assets/Scenes/DemoLevel.unity
+++ b/Assets/Scenes/DemoLevel.unity
@@ -2872,6 +2872,36 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   parallaxEffectMultiplier: 0.4
+--- !u!1 &846256296
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 846256297}
+  m_Layer: 10
+  m_Name: ParryPoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &846256297
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 846256296}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.39, y: 0.88, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 982059460}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &848331418
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -3311,6 +3341,7 @@ Transform:
   - {fileID: 619630039}
   - {fileID: 1478519005}
   - {fileID: 1289604727}
+  - {fileID: 846256297}
   - {fileID: 2122231732}
   - {fileID: 1912721193}
   m_Father: {fileID: 0}
@@ -3435,6 +3466,7 @@ MonoBehaviour:
   wepRange: 0.5
   playerAttackSpeed: 0.3
   attackPoint: {fileID: 1289604727}
+  parryPoint: {fileID: 846256297}
   canAttack: 1
   stunStrength: 1
   playerStunned: 0
@@ -6326,7 +6358,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 982059460}
-  m_RootOrder: 4
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1917679336
 GameObject:
@@ -7023,7 +7055,7 @@ RectTransform:
   m_Children:
   - {fileID: 1356687766}
   m_Father: {fileID: 982059460}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}

--- a/Assets/_Enemy Scripts/EnemyBossBandit.cs
+++ b/Assets/_Enemy Scripts/EnemyBossBandit.cs
@@ -119,7 +119,7 @@ public class EnemyBossBandit : MonoBehaviour
                     break;
                 case "Attack1_SlowStartCombo3":
                     combo3Attack1AnimTime = clip.length;
-                    Debug.Log("Attack1SlowaoejpfaoeCombo3: " + combo3Attack1AnimTime);
+                    Debug.Log("Attack1SlowCombo3: " + combo3Attack1AnimTime);
                     break;
             }
         }

--- a/Assets/_Player Scripts/PlayerInput (Old)/CharacterController2D.cs
+++ b/Assets/_Player Scripts/PlayerInput (Old)/CharacterController2D.cs
@@ -19,7 +19,6 @@ public class CharacterController2D : MonoBehaviour
 
 	const float k_GroundedRadius = .2f; // Radius of the overlap circle to determine if grounded
 	private bool m_Grounded;            // Whether or not the player is grounded.
-	const float k_CeilingRadius = .2f; // Radius of the overlap circle to determine if the player can stand up
 	private Rigidbody2D m_Rigidbody2D;
 	public bool m_FacingRight = true;  // For determining which way the player is currently facing.
 	private Vector3 m_Velocity = Vector3.zero;

--- a/Assets/_Player Scripts/PlayerInput (Old)/CharacterController2D.cs
+++ b/Assets/_Player Scripts/PlayerInput (Old)/CharacterController2D.cs
@@ -92,7 +92,6 @@ public class CharacterController2D : MonoBehaviour
 					Flip();
 					attackPoint.localScale *= -1;
 				}
-				// Otherwise if the input is moving the player left and the player is facing right...
 				else if (move < 0 && m_FacingRight)
 				{
 					Flip();
@@ -109,6 +108,8 @@ public class CharacterController2D : MonoBehaviour
         }
 	}
 
+
+
 	public void DisableFlip()
 	{
 		canFlip = false;
@@ -118,16 +119,6 @@ public class CharacterController2D : MonoBehaviour
 	{
 		canFlip = true;
 	}
-
-	/*private void Flip()
-	{
-		if (canFlip)
-		{
-			FacingDirection *= -1;
-			transform.Rotate(0.0f, 180.0f, 0.0f);
-		}
-
-	}*/
 
 	private void Flip()
 	{

--- a/Assets/_Player Scripts/PlayerInput (Old)/PlayerMovement.cs
+++ b/Assets/_Player Scripts/PlayerInput (Old)/PlayerMovement.cs
@@ -38,7 +38,7 @@ public class PlayerMovement : MonoBehaviour
     float horizontalMove = 0f;
     bool jump = false;
 
-    public bool canMove = true;
+    public bool canMove;
 
     //created new separate from CharacterController2D
     public bool isGrounded = true;
@@ -64,50 +64,10 @@ public class PlayerMovement : MonoBehaviour
         }
         
         animator.SetFloat("Speed", Mathf.Abs(horizontalMove)); //greater than 0 -> play run anim, less than -> play idle
-        //animator.SetBool("Grounded", true);
 
-        if (horizontalMove > 0)
-        {
-            m_facingDirection = 1;
-        }
-        else if(horizontalMove < 0)
-        {
-            m_facingDirection = -1;
-        }
+        FacingDirection();
 
-        if (Input.GetButtonDown("Jump") && rb.velocity.y == 0)
-        //if (keyboard.spaceKey.isPressed && rb.velocity.y == 0)
-        {
-            if (canMove)
-                rb.AddForce(Vector2.up * 100f);
-                
-            //jump = true;
-            //animator.SetBool("Grounded", false);
-            //animator.SetBool("Jumping", true);
-        }
-
-        //checking if player is jumping or falling
-        //if (Mathf.Abs(horizontalMove) > 0 && rb.velocity.y == 0)
-        if (rb.velocity.y == 0) //player is grounded
-        {
-            animator.SetBool("Jumping", false);
-            animator.SetBool("isFalling", false);
-            isGrounded = true;
-        }
-
-        //bool check on Jumping to prevent launching when colliding with wall
-        if (rb.velocity.y > 0 && !animator.GetBool("Jumping"))
-        {
-            animator.SetBool("Jumping", true);
-            jump = true;
-            isGrounded = false;
-        }
-
-        if(rb.velocity.y < 0)
-        {
-            animator.SetBool("Jumping", false);
-            animator.SetBool("isFalling", true);
-        }
+        JumpCheck();
 
         //Dodge Roll
         CheckDodge();
@@ -128,6 +88,52 @@ public class PlayerMovement : MonoBehaviour
             runSpeed = 0f;
 
         jump = false;
+    }
+
+    void FacingDirection()
+    {
+        if (horizontalMove > 0)
+        {
+            m_facingDirection = 1;
+        }
+        else if(horizontalMove< 0)
+        {
+            m_facingDirection = -1;
+        }
+    }
+
+    void JumpCheck()
+    {
+        if (Input.GetButtonDown("Jump") && rb.velocity.y == 0)
+        //if (keyboard.spaceKey.isPressed && rb.velocity.y == 0)
+        {
+            if (canMove)
+                rb.AddForce(Vector2.up * 100f);
+
+        }
+
+        //checking if player is jumping or falling
+        //if (Mathf.Abs(horizontalMove) > 0 && rb.velocity.y == 0)
+        if (rb.velocity.y == 0) //player is grounded
+        {
+            animator.SetBool("Jumping", false);
+            animator.SetBool("isFalling", false);
+            isGrounded = true;
+        }
+
+        //bool check on Jumping to prevent launching when colliding with wall
+        if (rb.velocity.y > 0 && !animator.GetBool("Jumping"))
+        {
+            animator.SetBool("Jumping", true);
+            jump = true;
+            isGrounded = false;
+        }
+
+        if (rb.velocity.y < 0)
+        {
+            animator.SetBool("Jumping", false);
+            animator.SetBool("isFalling", true);
+        }
     }
 
     void CheckDodge()
@@ -194,7 +200,7 @@ public class PlayerMovement : MonoBehaviour
         {
             if (dashTimeLeft > 0)
             {
-                canMove = false;
+                DisableMove();
                 controller.canFlip = false;
                 rb.velocity = new Vector2(dashSpeed * m_facingDirection, rb.velocity.y);
                 dashTimeLeft -= Time.deltaTime;
@@ -209,10 +215,24 @@ public class PlayerMovement : MonoBehaviour
             if(dashTimeLeft <= 0)
             {
                 isDashing = false;
-                canMove = true;
+                EnableMove();
                 controller.canFlip = true;
             }
         }
     }
 
+    public void CheckMove()
+    {
+        //
+    }
+
+    public void EnableMove()
+    {
+        canMove = true;
+    }
+
+    public void DisableMove()
+    {
+        canMove = false;
+    }
 }


### PR DESCRIPTION
Fixed player sliding on attacks.
Fixed Heavy and Light attack coroutines starting at the same time.
Fixed attackSpeed in PlayerCombat script, too many separate variables affecting the same property.