### PR TITLE
Bug and animations fixes

### DIFF
--- a/Assets/Assets/_Parallax Background/ParallaxBackground.cs
+++ b/Assets/Assets/_Parallax Background/ParallaxBackground.cs
@@ -21,15 +21,18 @@ public class ParallaxBackground : MonoBehaviour
 
     private void FixedUpdate() //FixedUpdate prevents jittery effect on scrolling
     {
+        /*Vector3 deltaMovement = cameraTransform.position - lastCameraPosition;
+        transform.position += deltaMovement * parallaxEffectMultiplier;
+        lastCameraPosition = cameraTransform.position;*/
+
         Vector3 deltaMovement = cameraTransform.position - lastCameraPosition;
         transform.position += deltaMovement * parallaxEffectMultiplier;
         lastCameraPosition = cameraTransform.position;
 
-        if(Mathf.Abs(cameraTransform.position.x - transform.position.x) >= textureUnitSizeX)
+        if (Mathf.Abs(cameraTransform.position.x - transform.position.x) >= textureUnitSizeX)
         {
             float offsetPositionX = (cameraTransform.position.x - transform.position.x) % textureUnitSizeX;
             transform.position = new Vector3(cameraTransform.position.x + offsetPositionX, transform.position.y);
-            
         }
     }
 }

--- a/Assets/Scenes/DemoLevel.unity
+++ b/Assets/Scenes/DemoLevel.unity
@@ -3156,7 +3156,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 519420028}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -3.4219775, y: -2.0022516, z: -1}
+  m_LocalPosition: {x: -3.4219775, y: -2, z: -1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
@@ -4984,6 +4984,7 @@ Transform:
   - {fileID: 1569115773}
   - {fileID: 2122231732}
   - {fileID: 1912721193}
+  - {fileID: 1739135140}
   m_Father: {fileID: 0}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -6450,8 +6451,10 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 1370011432}
-  - component: {fileID: 1370011434}
   - component: {fileID: 1370011435}
+  - component: {fileID: 1370011436}
+  - component: {fileID: 1370011434}
+  - component: {fileID: 1370011433}
   m_Layer: 0
   m_Name: ScreenShakeManager
   m_TagString: Untagged
@@ -6473,6 +6476,84 @@ Transform:
   m_Father: {fileID: 475092739}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1370011433
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1370011431}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 180ecf9b41d478f468eb3e9083753217, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ImpulseDefinition:
+    m_ImpulseChannel: 1
+    m_RawSignal: {fileID: 11400000, guid: 626ff4e3226d2924f82e053da2ad69e8, type: 2}
+    m_AmplitudeGain: 0.5
+    m_FrequencyGain: 1
+    m_RepeatMode: 0
+    m_Randomize: 1
+    m_TimeEnvelope:
+      m_AttackShape:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: -0.00021362305
+          outSlope: -0.00021362305
+          tangentMode: 34
+          weightedMode: 0
+          inWeight: 0
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0.9997864
+          inSlope: -0.00021362305
+          outSlope: -0.00021362305
+          tangentMode: 34
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      m_DecayShape:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0.95098877
+          inSlope: -0.0004267252
+          outSlope: -0.0004267252
+          tangentMode: 34
+          weightedMode: 0
+          inWeight: 0
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0.9505615
+          inSlope: -0.0004267252
+          outSlope: -0.0004267252
+          tangentMode: 34
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      m_AttackTime: 0
+      m_SustainTime: 0.05
+      m_DecayTime: 0.01
+      m_ScaleWithImpact: 0
+      m_HoldForever: 0
+    m_ImpactRadius: 50
+    m_DirectionMode: 1
+    m_DissipationMode: 2
+    m_DissipationDistance: 1000
+    m_PropagationSpeed: 343
 --- !u!114 &1370011434
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -6488,8 +6569,8 @@ MonoBehaviour:
   m_ImpulseDefinition:
     m_ImpulseChannel: 1
     m_RawSignal: {fileID: 11400000, guid: 626ff4e3226d2924f82e053da2ad69e8, type: 2}
-    m_AmplitudeGain: 1
-    m_FrequencyGain: 2
+    m_AmplitudeGain: 0.3
+    m_FrequencyGain: 0.6
     m_RepeatMode: 0
     m_Randomize: 1
     m_TimeEnvelope:
@@ -6564,6 +6645,88 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   placeholderVariable: 
+  enableScreenshake: 1
+  source1: {fileID: 1370011436}
+  source2: {fileID: 1370011434}
+  source3: {fileID: 1370011433}
+--- !u!114 &1370011436
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1370011431}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 180ecf9b41d478f468eb3e9083753217, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_ImpulseDefinition:
+    m_ImpulseChannel: 1
+    m_RawSignal: {fileID: 11400000, guid: 626ff4e3226d2924f82e053da2ad69e8, type: 2}
+    m_AmplitudeGain: 0.15
+    m_FrequencyGain: 0.25
+    m_RepeatMode: 0
+    m_Randomize: 1
+    m_TimeEnvelope:
+      m_AttackShape:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 1
+          inSlope: -0.00021362305
+          outSlope: -0.00021362305
+          tangentMode: 34
+          weightedMode: 0
+          inWeight: 0
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0.9997864
+          inSlope: -0.00021362305
+          outSlope: -0.00021362305
+          tangentMode: 34
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      m_DecayShape:
+        serializedVersion: 2
+        m_Curve:
+        - serializedVersion: 3
+          time: 0
+          value: 0.95098877
+          inSlope: -0.0004267252
+          outSlope: -0.0004267252
+          tangentMode: 34
+          weightedMode: 0
+          inWeight: 0
+          outWeight: 0.33333334
+        - serializedVersion: 3
+          time: 1
+          value: 0.9505615
+          inSlope: -0.0004267252
+          outSlope: -0.0004267252
+          tangentMode: 34
+          weightedMode: 0
+          inWeight: 0.33333334
+          outWeight: 0
+        m_PreInfinity: 2
+        m_PostInfinity: 2
+        m_RotationOrder: 4
+      m_AttackTime: 0
+      m_SustainTime: 0.05
+      m_DecayTime: 0.01
+      m_ScaleWithImpact: 0
+      m_HoldForever: 0
+    m_ImpactRadius: 50
+    m_DirectionMode: 1
+    m_DissipationMode: 2
+    m_DissipationDistance: 1000
+    m_PropagationSpeed: 343
 --- !u!1 &1380745742
 GameObject:
   m_ObjectHideFlags: 0
@@ -7053,6 +7216,7 @@ GameObject:
   - component: {fileID: 1516370766}
   - component: {fileID: 1516370768}
   - component: {fileID: 1516370769}
+  - component: {fileID: 1516370770}
   m_Layer: 0
   m_Name: CM vcam1
   m_TagString: Untagged
@@ -7079,7 +7243,7 @@ MonoBehaviour:
   m_Priority: 10
   m_StandbyUpdate: 2
   m_LookAt: {fileID: 0}
-  m_Follow: {fileID: 982059460}
+  m_Follow: {fileID: 1739135140}
   m_Lens:
     FieldOfView: 60
     OrthographicSize: 2.8
@@ -7103,7 +7267,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1516370765}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -3.4219775, y: -2.434517, z: -1}
+  m_LocalPosition: {x: -3.4219775, y: -2, z: -1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1779482179}
@@ -7142,6 +7306,19 @@ MonoBehaviour:
   m_ChannelMask: 1
   m_Gain: 1
   m_Use2DDistance: 1
+--- !u!114 &1516370770
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1516370765}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b90e007fa638f884c9b1a66c4eec7a53, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_YPosition: -2
 --- !u!850595691 &1534141446
 LightingSettings:
   m_ObjectHideFlags: 0
@@ -7411,19 +7588,19 @@ CompositeCollider2D:
   - m_Collider: {fileID: 1599150650}
     m_ColliderPaths:
     - - X: 675965083
-        Y: -17022516
+        Y: -19272518
       - X: 675965083
-        Y: 38977484
+        Y: 41227484
       - X: -65842668
-        Y: 38977191
+        Y: 41227191
       - X: -65842375
-        Y: -17022516
+        Y: -19272518
   m_CompositePaths:
     m_Paths:
-    - - {x: 67.59648, y: -1.7022517}
-      - {x: 67.59648, y: 3.8977485}
-      - {x: -6.5842667, y: 3.8976896}
-      - {x: -6.584208, y: -1.7022517}
+    - - {x: 67.59648, y: -1.9272518}
+      - {x: 67.59648, y: 4.1227484}
+      - {x: -6.5842667, y: 4.1226897}
+      - {x: -6.584208, y: -1.9272518}
   m_VertexDistance: 0.0005
   m_OffsetDistance: 0.00005
 --- !u!50 &1599150649
@@ -7471,7 +7648,7 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 74.1808, y: 5.6}
+  m_Size: {x: 74.1808, y: 6.05}
   m_EdgeRadius: 0
 --- !u!1 &1640498836
 GameObject:
@@ -7499,8 +7676,8 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1640498836}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.5, y: 0.46, z: 0.25}
-  m_LocalScale: {x: 1.2, y: 1.2, z: 1}
+  m_LocalPosition: {x: 0.5, y: 2.24, z: 0.25}
+  m_LocalScale: {x: 1.5, y: 1.71, z: 1}
   m_Children: []
   m_Father: {fileID: 1980092037}
   m_RootOrder: 13
@@ -7582,7 +7759,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 245630209313134784, guid: 5c4bb778b3d144241aefde28d57abe48, type: 3}
       propertyPath: maxHealth
-      value: 500
+      value: 50
       objectReference: {fileID: 0}
     - target: {fileID: 245630209313134784, guid: 5c4bb778b3d144241aefde28d57abe48, type: 3}
       propertyPath: TPOffset.y
@@ -8165,7 +8342,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 318c5df7279bf7c45a94596df0abbb1b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  prefab: {fileID: 3144434496805319467, guid: 0d10d273d6177714cb3b6a24e8705577, type: 3}
+  prefab: {fileID: 1558002513167808532, guid: d5d9b3113880a74409abbb2b3a3d947d, type: 3}
   poolSize: 5
   expandable: 1
 --- !u!114 &1735380980
@@ -8181,6 +8358,36 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   HitEffectsPool: {fileID: 1735380979}
+--- !u!1 &1739135139
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1739135140}
+  m_Layer: 10
+  m_Name: CameraFocusPoint
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1739135140
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1739135139}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0.9, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 982059460}
+  m_RootOrder: 9
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1779207308
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/DemoLevel.unity
+++ b/Assets/Scenes/DemoLevel.unity
@@ -3156,7 +3156,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 519420028}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -3.4219775, y: -2, z: -1}
+  m_LocalPosition: {x: -3.4219775, y: -2.2, z: -1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
@@ -6491,8 +6491,8 @@ MonoBehaviour:
   m_ImpulseDefinition:
     m_ImpulseChannel: 1
     m_RawSignal: {fileID: 11400000, guid: 626ff4e3226d2924f82e053da2ad69e8, type: 2}
-    m_AmplitudeGain: 0.5
-    m_FrequencyGain: 1
+    m_AmplitudeGain: 0.3
+    m_FrequencyGain: 0.6
     m_RepeatMode: 0
     m_Randomize: 1
     m_TimeEnvelope:
@@ -6569,8 +6569,8 @@ MonoBehaviour:
   m_ImpulseDefinition:
     m_ImpulseChannel: 1
     m_RawSignal: {fileID: 11400000, guid: 626ff4e3226d2924f82e053da2ad69e8, type: 2}
-    m_AmplitudeGain: 0.3
-    m_FrequencyGain: 0.6
+    m_AmplitudeGain: 0.1
+    m_FrequencyGain: 0.2
     m_RepeatMode: 0
     m_Randomize: 1
     m_TimeEnvelope:
@@ -6664,8 +6664,8 @@ MonoBehaviour:
   m_ImpulseDefinition:
     m_ImpulseChannel: 1
     m_RawSignal: {fileID: 11400000, guid: 626ff4e3226d2924f82e053da2ad69e8, type: 2}
-    m_AmplitudeGain: 0.15
-    m_FrequencyGain: 0.25
+    m_AmplitudeGain: 0.05
+    m_FrequencyGain: 0.1
     m_RepeatMode: 0
     m_Randomize: 1
     m_TimeEnvelope:
@@ -7267,7 +7267,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1516370765}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -3.4219775, y: -2, z: -1}
+  m_LocalPosition: {x: -3.4219775, y: -2.2, z: -1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1779482179}
@@ -7318,7 +7318,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b90e007fa638f884c9b1a66c4eec7a53, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  m_YPosition: -2
+  m_YPosition: -2.2
 --- !u!850595691 &1534141446
 LightingSettings:
   m_ObjectHideFlags: 0
@@ -7588,19 +7588,19 @@ CompositeCollider2D:
   - m_Collider: {fileID: 1599150650}
     m_ColliderPaths:
     - - X: 675965083
-        Y: -19272518
+        Y: -19400000
       - X: 675965083
-        Y: 41227484
+        Y: 38800000
       - X: -65842668
-        Y: 41227191
+        Y: 38799707
       - X: -65842375
-        Y: -19272518
+        Y: -19400000
   m_CompositePaths:
     m_Paths:
-    - - {x: 67.59648, y: -1.9272518}
-      - {x: 67.59648, y: 4.1227484}
-      - {x: -6.5842667, y: 4.1226897}
-      - {x: -6.584208, y: -1.9272518}
+    - - {x: 67.59648, y: -1.94}
+      - {x: 67.59648, y: 3.88}
+      - {x: -6.5842667, y: 3.8799417}
+      - {x: -6.584208, y: -1.94}
   m_VertexDistance: 0.0005
   m_OffsetDistance: 0.00005
 --- !u!50 &1599150649
@@ -7637,7 +7637,7 @@ BoxCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 1
-  m_Offset: {x: 30.506134, y: 1.0977483}
+  m_Offset: {x: 30.506134, y: 0.97}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0, y: 0}
@@ -7648,7 +7648,7 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 74.1808, y: 6.05}
+  m_Size: {x: 74.1808, y: 5.82}
   m_EdgeRadius: 0
 --- !u!1 &1640498836
 GameObject:
@@ -8382,7 +8382,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1739135139}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.9, z: 0}
+  m_LocalPosition: {x: 0, y: 0.74, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 982059460}
@@ -8517,7 +8517,7 @@ MonoBehaviour:
   m_ZDamping: 1
   m_TargetMovementOnly: 1
   m_ScreenX: 0.5
-  m_ScreenY: 0.644
+  m_ScreenY: 0.63
   m_CameraDistance: 1
   m_DeadZoneWidth: 0
   m_DeadZoneHeight: 0
@@ -11134,6 +11134,10 @@ PrefabInstance:
       propertyPath: playerCombat
       value: 
       objectReference: {fileID: 982059469}
+    - target: {fileID: 8396513380961675702, guid: a6783f52ea0250e46a6acfbe48d0f85f, type: 3}
+      propertyPath: enAttackDamage
+      value: 5
+      objectReference: {fileID: 0}
     - target: {fileID: 8396513380961675702, guid: a6783f52ea0250e46a6acfbe48d0f85f, type: 3}
       propertyPath: HitEffectsHandler
       value: 

--- a/Assets/ScreenShakeListener.cs
+++ b/Assets/ScreenShakeListener.cs
@@ -6,15 +6,31 @@ public class ScreenShakeListener : MonoBehaviour
     [Header("*This uses Cinemachine, camera bounds will affect the screenshake.")]
     public string placeholderVariable = "";
 
-    private CinemachineImpulseSource source;
+    public bool enableScreenshake = true;
+    //Sources listed in order of impulse strength
+    public CinemachineImpulseSource source1;
+    public CinemachineImpulseSource source2;
+    public CinemachineImpulseSource source3;
 
-    private void Awake()
+    public void Shake(int sourceChoice = 1)
     {
-        source = GetComponent<CinemachineImpulseSource>();
-    }
-
-    public void Shake()
-    {
-        source.GenerateImpulse();
+        if (enableScreenshake)
+        {
+            switch (sourceChoice)
+            {
+                case 1:
+                    source1.GenerateImpulse();
+                    break;
+                case 2:
+                    source2.GenerateImpulse();
+                    break;
+                case 3:
+                    source3.GenerateImpulse();
+                    break;
+                default:
+                    Debug.Log("No impulse source.");
+                    break;
+            }
+        }
     }
 }

--- a/Assets/ScreenShakeListener.cs
+++ b/Assets/ScreenShakeListener.cs
@@ -14,7 +14,7 @@ public class ScreenShakeListener : MonoBehaviour
 
     public void Shake(int sourceChoice = 1)
     {
-        if (enableScreenshake)
+        if (enableScreenshake && source1 != null)
         {
             switch (sourceChoice)
             {
@@ -28,7 +28,7 @@ public class ScreenShakeListener : MonoBehaviour
                     source3.GenerateImpulse();
                     break;
                 default:
-                    Debug.Log("No impulse source.");
+                    //Debug.Log("No impulse source.");
                     break;
             }
         }

--- a/Assets/TriggerCheck.cs
+++ b/Assets/TriggerCheck.cs
@@ -18,7 +18,7 @@ public class TriggerCheck : MonoBehaviour
         if (combat.IsShieldBashing)
         {
             //check for ShieldBash input, either in PlayerCombat after .2f charge up delay in ShieldBashStart()
-            ApplyCollision(collision.gameObject, true);
+            ApplyCollision(collision.gameObject); 
         }
         else
         {
@@ -30,7 +30,7 @@ public class TriggerCheck : MonoBehaviour
     {
     }
 
-    public void ApplyCollision(GameObject collider, bool overrideDash = false)
+    public void ApplyCollision(GameObject collider, bool overrideDash = false) //overrideDash - if an enemy is already in the trigger, don't dash at all
     {
         if (movement.isDashing || overrideDash)
         {

--- a/Assets/_Enemy Scripts/Enemy.cs
+++ b/Assets/_Enemy Scripts/Enemy.cs
@@ -311,7 +311,7 @@ public class Enemy : MonoBehaviour
             }
             
             //hurt animation
-            if (enAnimator != null && damage > 0) //took damage, not heal 
+            if (enAnimator != null && damage > 0) //took damage, not heal
             {
                 //stopping coroutine
                 //attackStopped = true;

--- a/Assets/_Player Scripts/PlayerInput (Old)/PlayerCombat.cs
+++ b/Assets/_Player Scripts/PlayerInput (Old)/PlayerCombat.cs
@@ -159,6 +159,7 @@ public class PlayerCombat : MonoBehaviour
         {
             //RevivePlayer(1.0f); //1.0 = 100%, 0.5 = 50%
             controller.RespawnPlayerResetLevel();
+            timeManager.ResetTimeScale();
         }
 
         if (Input.GetKeyDown(KeyCode.H))
@@ -166,6 +167,24 @@ public class PlayerCombat : MonoBehaviour
             HealPlayer(25f); //how much health to heal
         }
         /////////////////////////////////////////////////////////////////////////////////////////////
+        /////////////////////////////////////////////////////////////////////////////////////////////
+
+        if (Input.GetKeyDown(KeyCode.Alpha1))
+        {
+            screenShake.Shake(1);
+        }
+
+        if (Input.GetKeyDown(KeyCode.Alpha2))
+        {
+            screenShake.Shake(2);
+        }
+
+        if (Input.GetKeyDown(KeyCode.Alpha3))
+        {
+            screenShake.Shake(3);
+        }
+
+
         /////////////////////////////////////////////////////////////////////////////////////////////
     }
     void UpdateAbilityDisplay()
@@ -272,6 +291,7 @@ public class PlayerCombat : MonoBehaviour
         {
             if(enemy.GetComponent<EnemyController>() != null) //after migrating below functions into EnemyController
             {
+                timeManager.DoFreezeTime(.1f, .05f);
                 //screenShake.Shake();
                 /*enemy.GetComponent<EnemyController>().TakeDamage(attackDamageLight);
                 enemy.GetComponent<EnemyController>().GetKnockback(knockback/2);
@@ -390,8 +410,8 @@ public class PlayerCombat : MonoBehaviour
                 {
                     if (enemy.GetComponent<EnemyController>() != null)
                     {
-                        /*if(enableScreenshake)
-                            screenShake.Shake();*/
+                        if(enableScreenshake)
+                            screenShake.Shake();
 
                         timeManager.DoFreezeTime(.1f, .05f);
                         //TODO: move common enemy scripting to EnemyController, instead of calling individual TakeDamage scripts
@@ -423,8 +443,8 @@ public class PlayerCombat : MonoBehaviour
                 {
                     if (enemy.GetComponent<EnemyController>() != null)
                     {
-                        /*if(enableScreenshake)
-                            screenShake.Shake();*/
+                        if(enableScreenshake)
+                            screenShake.Shake();
 
                         timeManager.DoFreezeTime(.2f);
                         //TODO: move common enemy scripting to EnemyController, instead of calling individual TakeDamage scripts
@@ -610,6 +630,8 @@ public class PlayerCombat : MonoBehaviour
         //disable collider on hit
         if (enableScreenshake)
             screenShake.Shake();
+
+        timeManager.DoFreezeTime(.1f, .05f);
 
         StartCoroutine(ShieldBashEnd());
     }
@@ -821,7 +843,7 @@ public class PlayerCombat : MonoBehaviour
     public void GiveXP(float xp)
     {
         experienceBar.AddXP(xp);
-        //timeManager.DoFreezeTime(.1f); //short freeze on kill
+        timeManager.DoFreezeTime(.05f); //short freeze on kill
         xpPopups.ShowText(transform.position, "+" + xp + "xp");
     }
 

--- a/Assets/_Player Scripts/PlayerInput (Old)/PlayerCombat.cs
+++ b/Assets/_Player Scripts/PlayerInput (Old)/PlayerCombat.cs
@@ -168,24 +168,6 @@ public class PlayerCombat : MonoBehaviour
         }
         /////////////////////////////////////////////////////////////////////////////////////////////
         /////////////////////////////////////////////////////////////////////////////////////////////
-
-        if (Input.GetKeyDown(KeyCode.Alpha1))
-        {
-            screenShake.Shake(1);
-        }
-
-        if (Input.GetKeyDown(KeyCode.Alpha2))
-        {
-            screenShake.Shake(2);
-        }
-
-        if (Input.GetKeyDown(KeyCode.Alpha3))
-        {
-            screenShake.Shake(3);
-        }
-
-
-        /////////////////////////////////////////////////////////////////////////////////////////////
     }
     void UpdateAbilityDisplay()
     {
@@ -255,7 +237,7 @@ public class PlayerCombat : MonoBehaviour
                 yield return new WaitForSeconds(0.1f);
                 break;
             case 2:
-                yield return new WaitForSeconds(0.1f);
+                yield return new WaitForSeconds(0.05f);
                 Attack();
                 canSwitch = true;
                 yield return new WaitForSeconds(0.1f);
@@ -291,7 +273,7 @@ public class PlayerCombat : MonoBehaviour
         {
             if(enemy.GetComponent<EnemyController>() != null) //after migrating below functions into EnemyController
             {
-                timeManager.DoFreezeTime(.1f, .05f);
+                timeManager.DoFreezeTime(.1f, .05f); //freezeDuration, delayToFreeze
                 //screenShake.Shake();
                 /*enemy.GetComponent<EnemyController>().TakeDamage(attackDamageLight);
                 enemy.GetComponent<EnemyController>().GetKnockback(knockback/2);
@@ -366,19 +348,19 @@ public class PlayerCombat : MonoBehaviour
         switch (attackNum)
         {
             case 1:
-                yield return new WaitForSeconds(0.4f);
+                yield return new WaitForSeconds(0.3f);
                 AttackHeavy();
                 canSwitch = true;
                 yield return new WaitForSeconds(0.2f);
                 break;
             case 2:
-                yield return new WaitForSeconds(0.3f); //Attack functions determine damage and attack hitbox
+                yield return new WaitForSeconds(0.25f); //Attack functions determine damage and attack hitbox
                 AttackHeavy(2); //using hitbox 2
                 canSwitch = true;
                 yield return new WaitForSeconds(0.1f);
                 break;
             case 3:
-                yield return new WaitForSeconds(0.3f);
+                yield return new WaitForSeconds(0.25f);
                 AttackHeavy(1, 1.5f); //default 1, 1.5x damage
                 canSwitch = true;
                 yield return new WaitForSeconds(0.2f);
@@ -413,7 +395,7 @@ public class PlayerCombat : MonoBehaviour
                         if(enableScreenshake)
                             screenShake.Shake();
 
-                        timeManager.DoFreezeTime(.1f, .05f);
+                        timeManager.DoFreezeTime(.15f, .05f); //.1, .05
                         //TODO: move common enemy scripting to EnemyController, instead of calling individual TakeDamage scripts
                     }
 
@@ -446,7 +428,7 @@ public class PlayerCombat : MonoBehaviour
                         if(enableScreenshake)
                             screenShake.Shake();
 
-                        timeManager.DoFreezeTime(.2f);
+                        timeManager.DoFreezeTime(.15f, .05f);
                         //TODO: move common enemy scripting to EnemyController, instead of calling individual TakeDamage scripts
                     }
 
@@ -629,10 +611,15 @@ public class PlayerCombat : MonoBehaviour
     {
         //disable collider on hit
         if (enableScreenshake)
-            screenShake.Shake();
+            screenShake.Shake(2);
 
         timeManager.DoFreezeTime(.1f, .05f);
 
+        StartCoroutine(ShieldBashEnd());
+    }
+
+    public void EndShieldBash() //calling if Bash doesn't connect
+    {
         StartCoroutine(ShieldBashEnd());
     }
 

--- a/Assets/_Player Scripts/PlayerInput (Old)/PlayerMovement.cs
+++ b/Assets/_Player Scripts/PlayerInput (Old)/PlayerMovement.cs
@@ -258,7 +258,7 @@ public class PlayerMovement : MonoBehaviour
     {
         if (isDashing)
         {
-            playerCombat.OnSuccessfulBash();
+            playerCombat.EndShieldBash();
             dashTimeLeft = 0; //only needed when CancelDash is called elsewhere
             isDashing = false;
             StartCoroutine(EndDash());

--- a/Assets/_Prefabs/HealthBarCanvas.prefab
+++ b/Assets/_Prefabs/HealthBarCanvas.prefab
@@ -232,6 +232,7 @@ MonoBehaviour:
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 1
 --- !u!114 &5040420504116435329
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -304,6 +305,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 0
+    m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}
@@ -357,6 +359,7 @@ MonoBehaviour:
   currentHealth: 0
   maxHealth: 0
   healthNumbers: {fileID: 0}
+  slowTrail: 0
 --- !u!1 &5040420504409480432
 GameObject:
   m_ObjectHideFlags: 0
@@ -590,6 +593,7 @@ MonoBehaviour:
   m_FallbackScreenDPI: 96
   m_DefaultSpriteDPI: 96
   m_DynamicPixelsPerUnit: 1
+  m_PresetInfoIsWorld: 0
 --- !u!114 &3981235064464331029
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -621,6 +625,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   m_Navigation:
     m_Mode: 3
+    m_WrapAround: 0
     m_SelectOnUp: {fileID: 0}
     m_SelectOnDown: {fileID: 0}
     m_SelectOnLeft: {fileID: 0}

--- a/Assets/_Scripts/LockCameraY.cs
+++ b/Assets/_Scripts/LockCameraY.cs
@@ -1,0 +1,25 @@
+using UnityEngine;
+using Cinemachine;
+
+//https://forum.unity.com/threads/follow-only-along-a-certain-axis.544511/
+
+[ExecuteInEditMode]
+[SaveDuringPlay]
+[AddComponentMenu("")] // Hide in menu
+public class LockCameraY : CinemachineExtension
+{
+    [Tooltip("Lock the camera's Y position to this value")]
+    public float m_YPosition = 10;
+
+    protected override void PostPipelineStageCallback(
+        CinemachineVirtualCameraBase vcam,
+        CinemachineCore.Stage stage, ref CameraState state, float deltaTime)
+    {
+        if (stage == CinemachineCore.Stage.Body)
+        {
+            var pos = state.RawPosition;
+            pos.y = m_YPosition;
+            state.RawPosition = pos;
+        }
+    }
+}

--- a/Assets/_Scripts/LockCameraY.cs.meta
+++ b/Assets/_Scripts/LockCameraY.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b90e007fa638f884c9b1a66c4eec7a53
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/_Scripts/TimeManager.cs
+++ b/Assets/_Scripts/TimeManager.cs
@@ -52,9 +52,14 @@ public class TimeManager : MonoBehaviour
         //isFrozen = true;
         Time.timeScale = 0f;
 
-        yield return new WaitForSecondsRealtime(freezeDuration);
+        yield return new WaitForSecondsRealtime(freezeDuration); //be careful this actually finishes or else timeScale is stuck at 0
 
         //isFrozen = false;
         Time.timeScale = 1f; //set timeScale back to default scale
+    }
+
+    public void ResetTimeScale()
+    {
+        Time.timeScale = 1f;
     }
 }


### PR DESCRIPTION
Screenshake was triggering on the end of ShieldBash even if not hitting.
Added a separate function to end the ShieldBash collider check without OnSuccessfulBash running.

Adjusted timing on attack animations to better correspond with when damage and timeFreeze are applied.
