### PR TITLE
Level Up changes

### DIFF
--- a/Assets/BossPhaseController.cs
+++ b/Assets/BossPhaseController.cs
@@ -1,0 +1,33 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class BossPhaseController : MonoBehaviour
+{
+    [SerializeField] int totalDamagePhases;
+
+    [SerializeField] float[] hpThreshold;
+
+    float hpThreshold1 = .25f;
+
+
+    // Start is called before the first frame update
+    void Start()
+    {
+        
+    }
+
+    public void UpdateHealth(float currentHP, float maxHP)
+    {
+        //if currentHP/maxHP
+        if((currentHP/maxHP) <= hpThreshold1)
+        {
+
+        }
+    }
+
+    private void SpawnEnemies()
+    {
+        //Set active selected enemy object
+    }
+}

--- a/Assets/BossPhaseController.cs.meta
+++ b/Assets/BossPhaseController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ac16935190eaf5047b3079d512397313
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Region1BossStage.unity
+++ b/Assets/Scenes/Region1BossStage.unity
@@ -250,6 +250,8 @@ RectTransform:
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_Children:
   - {fileID: 1478286603}
+  - {fileID: 425531158}
+  - {fileID: 1449986306}
   m_Father: {fileID: 1182070837881293146}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -343,7 +345,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 126022701}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -1.9732523, y: 0.4586079, z: -7.7898645}
+  m_LocalPosition: {x: 4.07, y: 0.4586079, z: -7.7898645}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 528098577}
@@ -429,7 +431,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 128730638}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 3.3, y: 0.58, z: 0.5}
+  m_LocalPosition: {x: 9.6, y: 0.58, z: 0.5}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 1980092037}
@@ -474,106 +476,6 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 12.784484, y: 0.47011137}
   m_EdgeRadius: 0
---- !u!1 &140445896
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 140445900}
-  - component: {fileID: 140445899}
-  - component: {fileID: 140445898}
-  - component: {fileID: 140445897}
-  m_Layer: 5
-  m_Name: Respawn Prompt
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &140445897
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 140445896}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: dc42784cf147c0c48a680349fa168899, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_IgnoreReversedGraphics: 1
-  m_BlockingObjects: 0
-  m_BlockingMask:
-    serializedVersion: 2
-    m_Bits: 4294967295
---- !u!114 &140445898
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 140445896}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 0cd44c1031e13a943bb63640046fad76, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_UiScaleMode: 0
-  m_ReferencePixelsPerUnit: 100
-  m_ScaleFactor: 1
-  m_ReferenceResolution: {x: 800, y: 600}
-  m_ScreenMatchMode: 0
-  m_MatchWidthOrHeight: 0
-  m_PhysicalUnit: 3
-  m_FallbackScreenDPI: 96
-  m_DefaultSpriteDPI: 96
-  m_DynamicPixelsPerUnit: 1
-  m_PresetInfoIsWorld: 0
---- !u!223 &140445899
-Canvas:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 140445896}
-  m_Enabled: 1
-  serializedVersion: 3
-  m_RenderMode: 0
-  m_Camera: {fileID: 0}
-  m_PlaneDistance: 100
-  m_PixelPerfect: 0
-  m_ReceivesEvents: 1
-  m_OverrideSorting: 0
-  m_OverridePixelPerfect: 0
-  m_SortingBucketNormalizedSize: 0
-  m_AdditionalShaderChannelsFlag: 25
-  m_SortingLayerID: -2144725635
-  m_SortingOrder: 1
-  m_TargetDisplay: 0
---- !u!224 &140445900
-RectTransform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 140445896}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 0, y: 0, z: 0}
-  m_Children:
-  - {fileID: 386487243}
-  m_Father: {fileID: 0}
-  m_RootOrder: 8
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 0, y: 0}
-  m_Pivot: {x: 0, y: 0}
 --- !u!1 &285095693
 GameObject:
   m_ObjectHideFlags: 0
@@ -843,7 +745,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   parallaxEffectMultiplier: 0.1
---- !u!1 &386487242
+--- !u!1 &425531157
 GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -851,43 +753,43 @@ GameObject:
   m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
-  - component: {fileID: 386487243}
-  - component: {fileID: 386487245}
-  - component: {fileID: 386487244}
+  - component: {fileID: 425531158}
+  - component: {fileID: 425531160}
+  - component: {fileID: 425531159}
   m_Layer: 5
-  m_Name: Respawn Prompt
+  m_Name: End of Demo (temp)
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!224 &386487243
+--- !u!224 &425531158
 RectTransform:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 386487242}
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_GameObject: {fileID: 425531157}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 140445900}
-  m_RootOrder: 0
+  m_Father: {fileID: 86264052}
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 1000, y: 500}
+  m_SizeDelta: {x: 583.2527, y: 193.7197}
   m_Pivot: {x: 0.5, y: 0.5}
---- !u!114 &386487244
+--- !u!114 &425531159
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 386487242}
-  m_Enabled: 0
+  m_GameObject: {fileID: 425531157}
+  m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
   m_Name: 
@@ -900,7 +802,9 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: Press 'Space' to restart
+  m_text: 'End of Demo
+
+'
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 7663332f3be7b6d4d91defb4e0d5fc76, type: 2}
   m_sharedMaterial: {fileID: 7670113837822391160, guid: 7663332f3be7b6d4d91defb4e0d5fc76, type: 2}
@@ -927,8 +831,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 60
-  m_fontSizeBase: 60
+  m_fontSize: 72
+  m_fontSizeBase: 72
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
@@ -960,7 +864,7 @@ MonoBehaviour:
   m_uvLineOffset: 0
   m_geometrySortingOrder: 0
   m_IsTextObjectScaleStatic: 0
-  m_VertexBufferAutoSizeReduction: 1
+  m_VertexBufferAutoSizeReduction: 0
   m_useMaxVisibleDescender: 1
   m_pageToDisplay: 1
   m_margin: {x: 0, y: 0, z: 0, w: 0}
@@ -969,13 +873,13 @@ MonoBehaviour:
   m_hasFontAssetChanged: 0
   m_baseMaterial: {fileID: 0}
   m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
---- !u!222 &386487245
+--- !u!222 &425531160
 CanvasRenderer:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 386487242}
+  m_GameObject: {fileID: 425531157}
   m_CullTransparentMesh: 1
 --- !u!1 &469985452
 GameObject:
@@ -1952,6 +1856,14 @@ PrefabInstance:
       propertyPath: HealthBarCanvas
       value: 
       objectReference: {fileID: 5040420503057490427}
+    - target: {fileID: 7730487714719235618, guid: abcb6f24dbda909418c15b2fc62728ba, type: 3}
+      propertyPath: playerCheckDistanceBack
+      value: -5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7730487714719235618, guid: abcb6f24dbda909418c15b2fc62728ba, type: 3}
+      propertyPath: playerCheckDistanceFront
+      value: -8
+      objectReference: {fileID: 0}
     - target: {fileID: 7730487714719235624, guid: abcb6f24dbda909418c15b2fc62728ba, type: 3}
       propertyPath: m_FlipY
       value: 0
@@ -1966,7 +1878,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 7730487714719235629, guid: abcb6f24dbda909418c15b2fc62728ba, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -4.58
+      value: 0.66
       objectReference: {fileID: 0}
     - target: {fileID: 7730487714719235629, guid: abcb6f24dbda909418c15b2fc62728ba, type: 3}
       propertyPath: m_LocalPosition.y
@@ -2120,13 +2032,147 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1373731381}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -3.3899999, y: 0, z: -1}
+  m_LocalPosition: {x: 0, y: 0, z: -1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 823039438}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1449986305
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1449986306}
+  - component: {fileID: 1449986308}
+  - component: {fileID: 1449986307}
+  m_Layer: 5
+  m_Name: Replay Prompt (temp)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1449986306
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1449986305}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 86264052}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: -222, y: -307}
+  m_SizeDelta: {x: 529.0247, y: 144.0108}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1449986307
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1449986305}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Replay previous stages
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 7663332f3be7b6d4d91defb4e0d5fc76, type: 2}
+  m_sharedMaterial: {fileID: 7670113837822391160, guid: 7663332f3be7b6d4d91defb4e0d5fc76, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 38.8
+  m_fontSizeBase: 38.8
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1449986308
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1449986305}
+  m_CullTransparentMesh: 1
 --- !u!1 &1478286602
 GameObject:
   m_ObjectHideFlags: 0
@@ -2204,7 +2250,9 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_text: '>'
+  m_text: '>
+
+'
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 7663332f3be7b6d4d91defb4e0d5fc76, type: 2}
   m_sharedMaterial: {fileID: 7670113837822391160, guid: 7663332f3be7b6d4d91defb4e0d5fc76, type: 2}
@@ -2369,7 +2417,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1599150646}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -1.856034, y: -3.1, z: -10.278398}
+  m_LocalPosition: {x: 4.19, y: -3.1, z: -10.278398}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
@@ -3134,6 +3182,10 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 0}
     - target: {fileID: 1182070838774948992, guid: 11738f450442c7b4eb650b310c3d98fc, type: 3}
+      propertyPath: ArrowIndicator
+      value: 
+      objectReference: {fileID: 86264051}
+    - target: {fileID: 1182070838774948992, guid: 11738f450442c7b4eb650b310c3d98fc, type: 3}
       propertyPath: playerInventory
       value: 
       objectReference: {fileID: 0}
@@ -3185,12 +3237,56 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1182070839613841674, guid: 11738f450442c7b4eb650b310c3d98fc, type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: -50
+      objectReference: {fileID: 0}
+    - target: {fileID: 1182070839694271048, guid: 11738f450442c7b4eb650b310c3d98fc, type: 3}
+      propertyPath: stage1
+      value: Stage1-1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1182070839694271048, guid: 11738f450442c7b4eb650b310c3d98fc, type: 3}
+      propertyPath: stage2
+      value: Stage1-2
+      objectReference: {fileID: 0}
     - target: {fileID: 1182070839694271049, guid: 11738f450442c7b4eb650b310c3d98fc, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 0.6
+      value: 6.86
       objectReference: {fileID: 0}
     - target: {fileID: 1182070839694271063, guid: 11738f450442c7b4eb650b310c3d98fc, type: 3}
       propertyPath: m_IsActive
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1182510674849205279, guid: 11738f450442c7b4eb650b310c3d98fc, type: 3}
+      propertyPath: m_LocalScale.x
+      value: 0.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1182510674849205279, guid: 11738f450442c7b4eb650b310c3d98fc, type: 3}
+      propertyPath: m_LocalScale.y
+      value: 0.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1182510674849205279, guid: 11738f450442c7b4eb650b310c3d98fc, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.53
+      objectReference: {fileID: 0}
+    - target: {fileID: 1182510674849205279, guid: 11738f450442c7b4eb650b310c3d98fc, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1182510674849205279, guid: 11738f450442c7b4eb650b310c3d98fc, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1182510674849205279, guid: 11738f450442c7b4eb650b310c3d98fc, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1182510674849205279, guid: 11738f450442c7b4eb650b310c3d98fc, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1182510674849205279, guid: 11738f450442c7b4eb650b310c3d98fc, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
@@ -3267,7 +3363,7 @@ Canvas:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5040420503057490427}
-  m_Enabled: 0
+  m_Enabled: 1
   serializedVersion: 3
   m_RenderMode: 0
   m_Camera: {fileID: 0}

--- a/Assets/Scenes/Region1BossStage.unity
+++ b/Assets/Scenes/Region1BossStage.unity
@@ -219,6 +219,84 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   parallaxEffectMultiplier: 0.7
+--- !u!1001 &60834061
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1293815766}
+    m_Modifications:
+    - target: {fileID: 1417789243664185653, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1417789243664185653, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5400267703687784548, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5400267703687784548, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6223926787818357787, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+      propertyPath: m_Name
+      value: Scarecrow (center)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6223926788253222146, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+      propertyPath: m_RootOrder
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6223926788253222146, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -3.13
+      objectReference: {fileID: 0}
+    - target: {fileID: 6223926788253222146, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6223926788253222146, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6223926788253222146, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6223926788253222146, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6223926788253222146, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6223926788253222146, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6223926788253222146, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6223926788253222146, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6223926788253222146, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+--- !u!4 &60834062 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6223926788253222146, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+  m_PrefabInstance: {fileID: 60834061}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &86264051
 GameObject:
   m_ObjectHideFlags: 0
@@ -351,7 +429,7 @@ Transform:
   - {fileID: 528098577}
   - {fileID: 285095695}
   m_Father: {fileID: 0}
-  m_RootOrder: 6
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &128730638
 GameObject:
@@ -881,6 +959,84 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 425531157}
   m_CullTransparentMesh: 1
+--- !u!1001 &441977634
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1293815766}
+    m_Modifications:
+    - target: {fileID: 1417789243664185653, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1417789243664185653, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5400267703687784548, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5400267703687784548, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6223926787818357787, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+      propertyPath: m_Name
+      value: Scarecrow (right)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6223926788253222146, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+      propertyPath: m_RootOrder
+      value: 3
+      objectReference: {fileID: 0}
+    - target: {fileID: 6223926788253222146, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.02
+      objectReference: {fileID: 0}
+    - target: {fileID: 6223926788253222146, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6223926788253222146, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6223926788253222146, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6223926788253222146, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6223926788253222146, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6223926788253222146, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6223926788253222146, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6223926788253222146, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6223926788253222146, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+--- !u!4 &441977635 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6223926788253222146, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+  m_PrefabInstance: {fileID: 441977634}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &469985452
 GameObject:
   m_ObjectHideFlags: 0
@@ -1838,6 +1994,9 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 1362493871}
+  - {fileID: 60834062}
+  - {fileID: 1573908660}
+  - {fileID: 441977635}
   m_Father: {fileID: 1182070837881293146}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -2390,6 +2549,84 @@ LightingSettings:
   m_PVRFilteringAtrousPositionSigmaDirect: 0.5
   m_PVRFilteringAtrousPositionSigmaIndirect: 2
   m_PVRFilteringAtrousPositionSigmaAO: 1
+--- !u!1001 &1573908659
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1293815766}
+    m_Modifications:
+    - target: {fileID: 1417789243664185653, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1417789243664185653, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5400267703687784548, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5400267703687784548, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6223926787818357787, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+      propertyPath: m_Name
+      value: Scarecrow (left)
+      objectReference: {fileID: 0}
+    - target: {fileID: 6223926788253222146, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+      propertyPath: m_RootOrder
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6223926788253222146, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -6.52
+      objectReference: {fileID: 0}
+    - target: {fileID: 6223926788253222146, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.2
+      objectReference: {fileID: 0}
+    - target: {fileID: 6223926788253222146, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6223926788253222146, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6223926788253222146, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6223926788253222146, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6223926788253222146, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6223926788253222146, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6223926788253222146, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6223926788253222146, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+--- !u!4 &1573908660 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6223926788253222146, guid: 7630f84b6cd6ae749b111f02fe13f25b, type: 3}
+  m_PrefabInstance: {fileID: 1573908659}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1599150646
 GameObject:
   m_ObjectHideFlags: 0
@@ -2444,19 +2681,19 @@ CompositeCollider2D:
   - m_Collider: {fileID: 1599150650}
     m_ColliderPaths:
     - - X: 34444603
-        Y: -19400000
+        Y: -18848614
       - X: 34444603
-        Y: 38800000
+        Y: 40178472
       - X: -64906872
-        Y: 38799707
+        Y: 40178179
       - X: -64906579
-        Y: -19400000
+        Y: -18848614
   m_CompositePaths:
     m_Paths:
-    - - {x: 3.4444313, y: -1.94}
-      - {x: 3.4444313, y: 3.88}
-      - {x: -6.4906874, y: 3.8799417}
-      - {x: -6.4906287, y: -1.94}
+    - - {x: 3.4444313, y: -1.8848615}
+      - {x: 3.4444313, y: 4.017847}
+      - {x: -6.4906874, y: 4.017789}
+      - {x: -6.4906287, y: -1.8848615}
   m_VertexDistance: 0.0005
   m_OffsetDistance: 0.00005
 --- !u!50 &1599150649
@@ -2493,7 +2730,7 @@ BoxCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 1
-  m_Offset: {x: -1.523099, y: 0.97}
+  m_Offset: {x: -1.523099, y: 1.0664928}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
     pivot: {x: 0, y: 0}
@@ -2504,7 +2741,7 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 9.935177, y: 5.82}
+  m_Size: {x: 9.935177, y: 5.9027085}
   m_EdgeRadius: 0
 --- !u!1 &1630885521
 GameObject:
@@ -3092,6 +3329,49 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   parallaxEffectMultiplier: -0.1
+--- !u!1 &1918644460
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1918644462}
+  - component: {fileID: 1918644461}
+  m_Layer: 0
+  m_Name: BossPhaseManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1918644461
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1918644460}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ac16935190eaf5047b3079d512397313, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!4 &1918644462
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1918644460}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.49107495, y: -0.5744137, z: -0.6496122}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1934179102
 GameObject:
   m_ObjectHideFlags: 0
@@ -3195,7 +3475,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1182070838774948995, guid: 11738f450442c7b4eb650b310c3d98fc, type: 3}
       propertyPath: m_RootOrder
-      value: 7
+      value: 8
       objectReference: {fileID: 0}
     - target: {fileID: 1182070838774948995, guid: 11738f450442c7b4eb650b310c3d98fc, type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/Scenes/TutorialStage/Player (HeroKnight).prefab
+++ b/Assets/Scenes/TutorialStage/Player (HeroKnight).prefab
@@ -287,7 +287,7 @@ MonoBehaviour:
   isAlive: 1
   wepDamage: 10
   wepRange: 0.5
-  playerAttackSpeed: 0.05
+  playerAttackSpeed: 0.2
   attackPoint: {fileID: 107596094163692448}
   heavyAttackPoint: {fileID: 107596094150175784}
   heavyAttackPointWide: {fileID: 107596093255308923}

--- a/Assets/Scenes/_NeverUnload.unity
+++ b/Assets/Scenes/_NeverUnload.unity
@@ -804,7 +804,7 @@ Canvas:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 140445896}
-  m_Enabled: 1
+  m_Enabled: 0
   serializedVersion: 3
   m_RenderMode: 0
   m_Camera: {fileID: 0}
@@ -3905,7 +3905,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 685120999}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 3.333561, y: -2.131967, z: -1}
+  m_LocalPosition: {x: 2.6669002, y: -2.0199995, z: -1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}

--- a/Assets/Scenes/_NeverUnload.unity
+++ b/Assets/Scenes/_NeverUnload.unity
@@ -4428,7 +4428,7 @@ BoxCollider2D:
   m_GameObject: {fileID: 823432693}
   m_Enabled: 1
   m_Density: 1
-  m_Material: {fileID: 0}
+  m_Material: {fileID: 6200000, guid: 3c1407bed3477cd47a77fd474e285681, type: 2}
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
@@ -9256,10 +9256,6 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 1177505292}
     - target: {fileID: 107596093386943514, guid: 77594f2070666cc4f86c4e88703164a3, type: 3}
-      propertyPath: wepDamage
-      value: 10
-      objectReference: {fileID: 0}
-    - target: {fileID: 107596093386943514, guid: 77594f2070666cc4f86c4e88703164a3, type: 3}
       propertyPath: screenShake
       value: 
       objectReference: {fileID: 1370011435}
@@ -9458,7 +9454,7 @@ Canvas:
   m_SortingBucketNormalizedSize: 0
   m_AdditionalShaderChannelsFlag: 25
   m_SortingLayerID: 0
-  m_SortingOrder: 0
+  m_SortingOrder: 1
   m_TargetDisplay: 0
 --- !u!224 &5455075831231226060
 RectTransform:

--- a/Assets/Scenes/_NeverUnload.unity
+++ b/Assets/Scenes/_NeverUnload.unity
@@ -1973,7 +1973,7 @@ GameObject:
   - component: {fileID: 386487245}
   - component: {fileID: 386487244}
   m_Layer: 5
-  m_Name: Respawn Prompt
+  m_Name: RespawnPrompText
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -2005,7 +2005,7 @@ MonoBehaviour:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 386487242}
-  m_Enabled: 0
+  m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
   m_Name: 
@@ -2020,7 +2020,7 @@ MonoBehaviour:
       m_Calls: []
   m_text: 'You have died.
 
-    Press Space to restart.'
+    Press Space to return to Menu.'
   m_isRightToLeft: 0
   m_fontAsset: {fileID: 11400000, guid: 7663332f3be7b6d4d91defb4e0d5fc76, type: 2}
   m_sharedMaterial: {fileID: 7670113837822391160, guid: 7663332f3be7b6d4d91defb4e0d5fc76, type: 2}
@@ -2047,8 +2047,8 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 60
-  m_fontSizeBase: 60
+  m_fontSize: 52
+  m_fontSizeBase: 52
   m_fontWeight: 400
   m_enableAutoSizing: 0
   m_fontSizeMin: 18
@@ -9290,7 +9290,7 @@ PrefabInstance:
     - target: {fileID: 107596093386943514, guid: 77594f2070666cc4f86c4e88703164a3, type: 3}
       propertyPath: respawnPrompt
       value: 
-      objectReference: {fileID: 0}
+      objectReference: {fileID: 140445896}
     - target: {fileID: 107596093386943514, guid: 77594f2070666cc4f86c4e88703164a3, type: 3}
       propertyPath: TextPopupsHandler
       value: 

--- a/Assets/_Enemy Scripts/Boss Enemies/BanditBossClass.cs
+++ b/Assets/_Enemy Scripts/Boss Enemies/BanditBossClass.cs
@@ -424,8 +424,9 @@ public class BanditBossClass : HeavyBanditClass
             DeathParticlesHandler.ShowHitEffect(deathParticleLocation);
         }
 
-        //Destroy(this.gameObject);
-        gameObject.SetActive(false); //TODO: set to false so that EndPortal can reference if isAlive
+        //gameObject.SetActive(false); //TODO: set to false so that EndPortal can reference if isAlive
+        stageClear.UpdateEnemyCount(100f, 50);
+        Destroy(this.gameObject);
     }
 
     private void OnDrawGizmosSelected()

--- a/Assets/_Player Scripts/PlayerInput (Old)/PlayerCombat.cs
+++ b/Assets/_Player Scripts/PlayerInput (Old)/PlayerCombat.cs
@@ -579,7 +579,7 @@ public class PlayerCombat : MonoBehaviour
 
         yield return new WaitForSeconds(.2f);
         canStunPlayer = true;
-        //Instantiate
+
         movement.EnableMove();
     }    
     #endregion

--- a/Assets/_Player Scripts/PlayerInput (Old)/PlayerCombat.cs
+++ b/Assets/_Player Scripts/PlayerInput (Old)/PlayerCombat.cs
@@ -38,7 +38,7 @@ public class PlayerCombat : MonoBehaviour
     public HealthBar healthBar;
     public ExperienceBar experienceBar;
     public bool isAlive = true;
-    bool canRespawn = false;
+    bool canRespawn;
     float allowStun;
     float allowStunCD = 1f;
 
@@ -111,6 +111,9 @@ public class PlayerCombat : MonoBehaviour
         sr = GetComponent<SpriteRenderer>();
         mDefault = sr.material;
 
+        if (respawnPrompt != null)
+            respawnPrompt.GetComponent<Canvas>().enabled = false;
+
         maxHealth = 100 + ((playerLevel - 1) * 10);
         experienceBar.SetXP(0, playerLevel);
 
@@ -137,6 +140,7 @@ public class PlayerCombat : MonoBehaviour
         IsShieldBashing = false;
         playerStunned = false;
         canStunPlayer = true;
+        canRespawn = false;
 
         shieldBashCollider.enabled = false;
         shieldBashTrigger.enabled = false;
@@ -165,7 +169,7 @@ public class PlayerCombat : MonoBehaviour
                 {
                     if(respawnPrompt != null)
                     {
-                        respawnPrompt.GetComponent<TextMeshProUGUI>().enabled = false;
+                        respawnPrompt.GetComponent<Canvas>().enabled = false;
                     }
                     //RevivePlayer(1.0f); //1.0 = 100%, 0.5 = 50%
                     //controller.RespawnPlayerResetLevel();
@@ -539,7 +543,9 @@ public class PlayerCombat : MonoBehaviour
     {
         IsShieldBashing = true; //starting to block damage
         canStunPlayer = false;
-        movement.DisableMove();
+
+        movement.DisableMove(false); //false to preserve current movement
+
         animator.SetTrigger("StartBlock");
         yield return new WaitForSeconds(.2f);
         shieldBashCollider.enabled = true; //
@@ -815,7 +821,7 @@ public class PlayerCombat : MonoBehaviour
         yield return new WaitForSeconds(1.0f);
         if (respawnPrompt != null)
         {
-            respawnPrompt.GetComponent<TextMeshProUGUI>().enabled = true;
+            respawnPrompt.GetComponent<Canvas>().enabled = true;
         }
         canRespawn = true;
     }

--- a/Assets/_Player Scripts/PlayerInput (Old)/PlayerCombat.cs
+++ b/Assets/_Player Scripts/PlayerInput (Old)/PlayerCombat.cs
@@ -46,7 +46,7 @@ public class PlayerCombat : MonoBehaviour
     //weapon stats
     public float wepDamage = 10f; //default values, should change based on weapon stats
     public float wepRange = .5f; //
-    public float playerAttackSpeed = .1f; //.3f
+    public float playerAttackSpeed = .2f; //.2f default
     private float playerHeavyAttackSpeed;
 
     public Transform attackPoint;
@@ -55,14 +55,12 @@ public class PlayerCombat : MonoBehaviour
     public Transform parryPoint;
     [SerializeField] float attackRange = .5f;
     [SerializeField] float attackHeavyRange = 0.58f;
-    float attackDamageLight;
-    float attackDamageHeavy;
     [SerializeField] float attackDamageHeavyMultiplier = 2.0f;
     public bool canAttack = true;
     public float stunStrength = 1f;
     [SerializeField] bool playerStunned;
 
-    public float attackTime = 0.25f; //0.25 seems good, give or take .1 seconds
+    public float attackTime = 0.25f; //0.25 seems good, +/- .1 seconds
 
     //armor stats
     public float playerArmor; //temp
@@ -116,6 +114,7 @@ public class PlayerCombat : MonoBehaviour
 
         maxHealth = 100 + ((playerLevel - 1) * 10);
         experienceBar.SetXP(0, playerLevel);
+        wepDamage += ((playerLevel - 1) * 2);
 
         //var keyboard = Keyboard.current; //temp workaround
         currentHealth = maxHealth;
@@ -130,9 +129,6 @@ public class PlayerCombat : MonoBehaviour
         playerHeavyAttackSpeed = (playerAttackSpeed * 1.25f);
         //attackDamageHeavyMultiplier = weapon.wepDamageHeavyMultiplier;
         //attackDamageHeavyMultiplier = 2.0f; //placeholder
-
-        attackDamageLight = wepDamage;
-        attackDamageHeavy = wepDamage*attackDamageHeavyMultiplier;
 
         canAttack = true;
         AltAttacking = false;
@@ -252,29 +248,26 @@ public class PlayerCombat : MonoBehaviour
             case 1:
                 yield return new WaitForSeconds(0.1f);
                 Attack();
-                canSwitch = true;
-                yield return new WaitForSeconds(0.1f);
+                //yield return new WaitForSeconds(playerAttackSpeed);
                 break;
             case 2:
                 yield return new WaitForSeconds(0.05f);
                 Attack();
-                canSwitch = true;
-                yield return new WaitForSeconds(0.1f);
+                //yield return new WaitForSeconds(playerAttackSpeed);
                 break;
             case 3:
                 yield return new WaitForSeconds(0.2f);
                 Attack(1.5f); // damage multiplier
-                canSwitch = true;
-                yield return new WaitForSeconds(0.1f);
+                //yield return new WaitForSeconds(playerAttackSpeed);
                 break;
             default:
                 yield return new WaitForSeconds(0.01f); //
                 break;
         }
-
+        canSwitch = true;
+        yield return new WaitForSeconds(playerAttackSpeed);
         canSwitch = false;
 
-        //yield return new WaitForSeconds(playerAttackSpeed);
         movement.canMove = true;
         canAttack = true;
         
@@ -292,8 +285,8 @@ public class PlayerCombat : MonoBehaviour
         {
             if(enemy.GetComponent<BaseEnemyClass>() != null)
             {
-                timeManager.DoFreezeTime(.1f, .05f); //freezeDuration, delayToFreeze
-                enemy.GetComponent<BaseEnemyClass>().TakeDamage(attackDamageLight, damageMultiplier); //attackDamage + additional damage from parameter
+                //timeManager.DoFreezeTime(.1f, .05f); //freezeDuration, delayToFreeze
+                enemy.GetComponent<BaseEnemyClass>().TakeDamage(wepDamage, damageMultiplier); //attackDamage + additional damage from parameter
                 enemy.GetComponent<BaseEnemyClass>().GetKnockback(controller.m_FacingRight);
             }
         }
@@ -349,28 +342,23 @@ public class PlayerCombat : MonoBehaviour
             case 1:
                 yield return new WaitForSeconds(0.35f);
                 AttackHeavy();
-                canSwitch = true;
-                yield return new WaitForSeconds(0.2f);
                 break;
             case 2:
                 yield return new WaitForSeconds(0.25f); //Attack functions determine damage and attack hitbox
                 AttackHeavy(2); //using hitbox 2
-                canSwitch = true;
-                yield return new WaitForSeconds(0.1f);
                 break;
             case 3:
                 yield return new WaitForSeconds(0.25f);
                 AttackHeavy(1, 1.5f); //default 1, 1.5x damage
-                canSwitch = true;
-                yield return new WaitForSeconds(0.2f);
                 break;
             default:
                 yield return new WaitForSeconds(0.01f); //
                 break;
         }
+        canSwitch = true;
+        yield return new WaitForSeconds(playerAttackSpeed + 0.1f);
         canSwitch = false;
 
-        //yield return new WaitForSeconds(playerAttackSpeed);
         movement.canMove = true;
         canAttack = true;
 
@@ -391,12 +379,12 @@ public class PlayerCombat : MonoBehaviour
                 {
                     if (enemy.GetComponent<BaseEnemyClass>() != null)
                     {
-                        timeManager.DoFreezeTime(.12f, .05f); //.1, .05
-
                         if (enableScreenshake)
                             screenShake.Shake();
+                        
+                        timeManager.DoFreezeTime(.1f, .05f); //.1, .05
 
-                        enemy.GetComponent<BaseEnemyClass>().TakeDamage(attackDamageHeavy, damageMultiplier); //attackDamage + additional damage from parameter
+                        enemy.GetComponent<BaseEnemyClass>().TakeDamage(wepDamage * attackDamageHeavyMultiplier, damageMultiplier); //attackDamage + additional damage from parameter
                         enemy.GetComponent<BaseEnemyClass>().GetKnockback(controller.m_FacingRight);
                     }
                 }
@@ -410,9 +398,9 @@ public class PlayerCombat : MonoBehaviour
                         if (enableScreenshake)
                             screenShake.Shake();
 
-                        timeManager.DoFreezeTime(.15f, .05f);
+                        timeManager.DoFreezeTime(.1f, .05f);
 
-                        enemy.GetComponent<BaseEnemyClass>().TakeDamage(attackDamageHeavy, damageMultiplier); //attackDamage + additional damage from parameter
+                        enemy.GetComponent<BaseEnemyClass>().TakeDamage(wepDamage * attackDamageHeavyMultiplier, damageMultiplier); //attackDamage + additional damage from parameter
                         enemy.GetComponent<BaseEnemyClass>().GetKnockback(controller.m_FacingRight);
                     }
                 }

--- a/Assets/_Scripts/_UI Scripts/ExperienceBar.cs
+++ b/Assets/_Scripts/_UI Scripts/ExperienceBar.cs
@@ -59,8 +59,11 @@ public class ExperienceBar : MonoBehaviour
         if (displayPlayerLevel != null) //update level
             displayPlayerLevel.text = currentPlayerLevel.ToString();
 
-        healthBar.SetMaxHealth(100 + ((currentPlayerLevel - 1) * 10f));
+        playerCombat.maxHealth += ((currentPlayerLevel - 1) *10f); //health +10/level
+        healthBar.SetMaxHealth(playerCombat.maxHealth);
         playerCombat.HealPlayer(healthBar.maxHealth);
+
+        playerCombat.wepDamage += ((currentPlayerLevel - 1) * 2); //damage +2/level
 
         xpPopups.ShowText(player.position, "\nLEVEL UP");
     }


### PR DESCRIPTION
### Bug Fixes
Fixed respawn prompt, we are toggling Canvas instead of TextMesh.
Respawn now returns Player to Menu.
Updated respawn prompt.

Removed velocity being set to 0 for ShieldBash, preserving movement at beginning of ability.

Added message to Boss Stage after clear.
Added Replay option to continue to loop through previous stages.
Repositioned UI text.

### Level Up

On Level Up, player gains +2 dmg/level and +10 hp/level.
Changed default Player attack speed values (ready for item implementation).

Fixed LevelUp not actually increasing player max HP, it was only increasing the UI.
UI is now updated from the player's maxHP. UI no longer holds values by itself, references PlayerCombat.